### PR TITLE
Add Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+sidekiq: bundle exec sidekiq


### PR DESCRIPTION
Adição de arquivo Procfile para rodar serviços localmente. 
Ele permite utilizar o [overmind](https://github.com/DarthSim/overmind?tab=readme-ov-file#usage) ou a gem [foreman](https://github.com/ddollar/foreman?tab=readme-ov-file) para subir o servidor rails e o processo do sidekiq de forma simplificada.