### PR TITLE
Adiciona jobs para abandonar e remover carrinhos

### DIFF
--- a/app/jobs/carts/mark_abandoned_job.rb
+++ b/app/jobs/carts/mark_abandoned_job.rb
@@ -1,0 +1,9 @@
+module Carts
+  class MarkAbandonedJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      Cart.without_interaction.find_each(batch_size: 1000, &:mark_as_abandoned)
+    end
+  end
+end

--- a/app/jobs/carts/remove_abandoned_job.rb
+++ b/app/jobs/carts/remove_abandoned_job.rb
@@ -1,0 +1,9 @@
+module Carts
+  class RemoveAbandonedJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      Cart.to_be_removed.find_each(batch_size: 1000, &:remove_if_abandoned)
+    end
+  end
+end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -7,6 +7,9 @@ class Cart < ApplicationRecord
 
   validates :total_price, numericality: { greater_than_or_equal_to: 0 }
 
+  scope :without_interaction, -> { where(last_interaction_at: ...HOURS_TO_ABANDON.hours.ago) }
+  scope :to_be_removed, -> { where(abandoned: true, last_interaction_at: ...DAYS_TO_REMOVE.days.ago) }
+
   def add_product(product_id, quantity = 1)
     find_or_create_cart_item(product_id, quantity)
     touch(:last_interaction_at)
@@ -17,6 +20,7 @@ class Cart < ApplicationRecord
     cart_item = cart_items.find_by(product_id: product_id)
     return unless cart_item
 
+    touch(:last_interaction_at)
     cart_item.remove_item
     update_total_price
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,3 +7,13 @@
   - mailers
   - active_storage_analysis
   - active_storage_purge
+
+
+:scheduler:
+  :schedule:
+    mark_abandoned_carts:
+      cron: '0 */3 * * *'   # Runs every 3 hours
+      class: Carts::MarkAbandonedJob
+    remove_abandoned_carts:
+      cron: '0 0 * * *'     # Runs daily at midnight
+      class: Carts::RemoveAbandonedJob


### PR DESCRIPTION
# Solution
- Adição de jobs para marcar como abandonado e remover carrinhos
- criação de scopes para buscar carrinhos nesses estados
- testes dos scopes
- assert para verificar alteração de última iteração
- configuração do schedule do sidekiq
